### PR TITLE
Prevent first loading by not dispatching an action when not needed

### DIFF
--- a/src/js/components/UserPage.jsx
+++ b/src/js/components/UserPage.jsx
@@ -1,15 +1,22 @@
 import React from 'react';
 import { connect } from 'redux/react';
 import { prepareRoute } from '../decorators';
+import { isUserLoaded } from '../reducers/User';
+import { isRepoLoadedForUser } from '../reducers/Repo';
 import * as RepoActionCreators from '../actions/repo';
 import * as UserActionCreators from '../actions/user';
 import RepoList from './RepoList';
 
 @prepareRoute(async function ({ redux, params: { username } }) {
-  return await * [
-    redux.dispatch(RepoActionCreators.getByUsername(username)),
-    redux.dispatch(UserActionCreators.getOneByUsername(username))
-  ];
+  const currentState = redux.getState();
+  let promises = [];
+  if(!isUserLoaded(currentState, username)) {
+    promises.push(redux.dispatch(UserActionCreators.getOneByUsername(username)));
+  }
+  if(!isRepoLoadedForUser(currentState, username)) {
+    promises.push(redux.dispatch(RepoActionCreators.getByUsername(username)));
+  }
+  return await * promises;
 })
 @connect(({ Repo, User }) => ({ Repo, User }))
 class UserPage extends React.Component {

--- a/src/js/reducers/Repo.js
+++ b/src/js/reducers/Repo.js
@@ -33,3 +33,7 @@ export default createReducer(initialState, {
     });
   }
 });
+
+export function isRepoLoadedForUser(state, username) {
+  return state.Repo.has(`users/${username}`);
+}

--- a/src/js/reducers/User.js
+++ b/src/js/reducers/User.js
@@ -12,3 +12,7 @@ export default createReducer(initialState, {
     });
   }
 });
+
+export function isUserLoaded(state, username) {
+  return state.User.has(username);
+}


### PR DESCRIPTION
First of all, thumbs up (:+1:) and thank you (:bow:) for building that repo.

Regarding avoiding the first loading on page load, that approach is borrowed from [react-redux-universal-hot-example](https://github.com/erikras/react-redux-universal-hot-example).

Another approach would be to dispatch an action, something like `UserActionCreators.getOneByUsernameIfNeeded` and perform the check inside there. 

What do you think?
